### PR TITLE
Refactor compilers to inherit from SQLite base classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 
+## [0.3.0]
+
+### Changed
+
+- Refactored compilers to inherit from SQLite base classes (`SQLiteCompiler`, `SQLiteDDLCompiler`, `SQLiteTypeCompiler`) instead of generic SQLAlchemy compilers for better SQLite compatibility
+
+### Added
+
+- Support for `INSERT ... ON CONFLICT DO UPDATE` (upsert operations) via SQLite dialect inheritance
+- New unit tests for upsert compilation, DDL generation, and compiler inheritance
+
+### Fixed
+
+- Fixed duplicate PRIMARY KEY constraint in CREATE TABLE statements (was generating both inline and separate constraint)
+- Fixed AUTOINCREMENT being incorrectly added to non-INTEGER PRIMARY KEY columns (D1 only supports AUTOINCREMENT on INTEGER PRIMARY KEY)
+
+
 ## [0.2.0]
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sqlalchemy-cloudflare-d1"
-version = "0.2.0"
+version = "0.3.0"
 description = "A SQLAlchemy dialect for Cloudflare's D1 Serverless SQLite Database"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary

- Refactored compilers to inherit from SQLite base classes (`SQLiteCompiler`, `SQLiteDDLCompiler`, `SQLiteTypeCompiler`) instead of generic SQLAlchemy compilers
- Adds support for `INSERT ... ON CONFLICT DO UPDATE` (upsert operations)
- Fixes duplicate PRIMARY KEY constraint in CREATE TABLE statements
- Fixes AUTOINCREMENT being incorrectly added to non-INTEGER PRIMARY KEY columns

## Changes

- `CloudflareD1Compiler` now inherits from `SQLiteCompiler`
- `CloudflareD1DDLCompiler` now inherits from `SQLiteDDLCompiler` with custom `get_column_specification` and `create_table_constraints` to handle D1-specific behavior
- `CloudflareD1TypeCompiler` now inherits from `SQLiteTypeCompiler`
- Added 4 new unit tests for upsert compilation, DDL generation, and inheritance verification

## Test plan

- [x] All 10 unit tests pass
- [x] Linting passes (ruff check/format)
- [x] Manual testing with langchain-cloudflare integration