### PR TITLE
Fix Boolean columns returning strings instead of Python bool (Issue #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 
+## [0.3.3]
+
+### Fixed
+
+- Fixed Boolean columns returning strings instead of Python `bool` ([#6](https://github.com/CollierKing/sqlalchemy-cloudflare-d1/issues/6))
+  - D1's API was converting Python booleans to strings (`"true"`/`"false"`) which broke filtering
+  - Added `D1Boolean` type class with `bind_processor` (converts `True`/`False` to `1`/`0`) and `result_processor` (converts responses back to Python `bool`)
+  - Boolean column filtering (`WHERE is_admin = True`) now works correctly
+- Fixed NULL parameter handling in Python Workers
+  - Python `None` was being converted to JavaScript `undefined` instead of `null`
+  - D1 rejected `undefined` values with `D1_TYPE_ERROR`
+  - Now uses `JSON.parse("null")` to get proper JavaScript `null` value
+
+
 ## [0.3.2]
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sqlalchemy-cloudflare-d1"
-version = "0.3.2"
+version = "0.3.3"
 description = "A SQLAlchemy dialect for Cloudflare's D1 Serverless SQLite Database"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -240,7 +240,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -922,7 +922,7 @@ wheels = [
 
 [[package]]
 name = "sqlalchemy-cloudflare-d1"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #6 

D1's API was converting Python booleans to strings which broke filtering. Added D1Boolean type with bind/result processors. 

Also fixed NULL parameter handling in Workers where Python None became JS undefined instead of null.

