### PR TITLE
Add Time type support, update README type mapping (Issue #18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 
+## [0.3.8]
+
+### Added
+
+- `Time` column type support ([#18](https://github.com/CollierKing/sqlalchemy-cloudflare-d1/issues/18))
+  - Added `D1Time` type processor that converts Python `time` objects to ISO 8601 strings on bind and parses them back on result
+  - Supports nullable time columns, time filtering/comparison, and ORM usage
+  - Works in both REST API and Worker modes
+
+### Changed
+
+- Updated README Type Mapping table to document all custom type processors (`D1Boolean`, `D1Date`, `D1Time`, `D1DateTime`, `D1LargeBinary`)
+
+
 ## [0.3.7]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -374,10 +374,11 @@ This dialect has some limitations due to D1's REST API nature:
 | `Text` | `TEXT` | |
 | `Float` | `REAL` | |
 | `Numeric` | `NUMERIC` | |
-| `Boolean` | `INTEGER` | Stored as 0/1 |
-| `DateTime` | `TEXT` | ISO format string |
-| `Date` | `TEXT` | ISO format string |
-| `Time` | `TEXT` | ISO format string |
+| `Boolean` | `INTEGER` | Stored as 0/1, auto-converted via `D1Boolean` |
+| `DateTime` | `TEXT` | ISO 8601 string, auto-converted via `D1DateTime` |
+| `Date` | `TEXT` | ISO 8601 string, auto-converted via `D1Date` |
+| `Time` | `TEXT` | ISO 8601 string, auto-converted via `D1Time` |
+| `LargeBinary` | `BLOB` | Base64-encoded, auto-converted via `D1LargeBinary` |
 
 ## Error Handling
 

--- a/examples/workers/uv.lock
+++ b/examples/workers/uv.lock
@@ -614,7 +614,7 @@ wheels = [
 
 [[package]]
 name = "sqlalchemy-cloudflare-d1"
-version = "0.3.7"
+version = "0.3.8"
 source = { editable = "../../" }
 dependencies = [
     { name = "httpx" },
@@ -640,6 +640,7 @@ provides-extras = ["async", "dev"]
 [package.metadata.requires-dev]
 dev = [
     { name = "codespell", specifier = ">=2.4.1" },
+    { name = "greenlet", specifier = ">=3.2.3" },
     { name = "mypy", specifier = ">=1.17.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pytest", specifier = ">=8.4.1" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sqlalchemy-cloudflare-d1"
-version = "0.3.7"
+version = "0.3.8"
 description = "A SQLAlchemy dialect for Cloudflare's D1 Serverless SQLite Database"
 readme = "README.md"
 authors = [

--- a/tests/integration/test_worker_integration.py
+++ b/tests/integration/test_worker_integration.py
@@ -910,3 +910,53 @@ class TestWorkerDateTimeColumn:
         assert data["origin_is_datetime"] is True
         assert data["indexed_is_datetime"] is True
         assert data["inserted_is_datetime"] is True
+
+
+# MARK: - Time Column Tests (Issue #18)
+
+
+class TestWorkerTimeColumn:
+    """Test Time column handling via Worker endpoints.
+
+    These tests mirror the TestTimeColumn tests in test_restapi_integration.py.
+    """
+
+    def test_time_insert_and_retrieve(self, dev_server):
+        """Test Time column insert and retrieve."""
+        port = dev_server
+        response = requests.get(f"http://localhost:{port}/time-basic")
+
+        assert response.status_code == 200, f"time_basic failed: {response.json()}"
+        data = response.json()
+
+        assert data["test"] == "time_basic"
+        assert data["success"] is True, f"time_basic failed: error={data.get('error')}"
+        assert data["event_time_type"] == "time"
+
+    def test_time_nullable(self, dev_server):
+        """Test nullable Time columns handle NULL correctly."""
+        port = dev_server
+        response = requests.get(f"http://localhost:{port}/time-nullable")
+
+        assert response.status_code == 200, f"time_nullable failed: {response.json()}"
+        data = response.json()
+
+        assert data["test"] == "time_nullable"
+        assert data["success"] is True, (
+            f"time_nullable failed: error={data.get('error')}"
+        )
+        assert data["with_time_is_time"] is True
+        assert data["no_time_is_none"] is True
+
+    def test_time_orm_session(self, dev_server):
+        """Test Time via ORM session."""
+        port = dev_server
+        response = requests.get(f"http://localhost:{port}/time-orm")
+
+        assert response.status_code == 200, f"time_orm failed: {response.json()}"
+        data = response.json()
+
+        assert data["test"] == "time_orm"
+        assert data["success"] is True, f"time_orm failed: error={data.get('error')}"
+        assert data["entry_title"] == "Time Test Entry"
+        assert data["start_time_is_time"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -922,7 +922,7 @@ wheels = [
 
 [[package]]
 name = "sqlalchemy-cloudflare-d1"
-version = "0.3.7"
+version = "0.3.8"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Add `D1Time` type processor for `sqlalchemy.Time` columns, preventing `D1_TYPE_ERROR` when inserting Python `time` objects
- Update README Type Mapping table to document all custom type processors (`D1Boolean`, `D1Date`, `D1Time`, `D1DateTime`, `D1LargeBinary`)
- Bump version to 0.3.8

## Test plan
- [x] 4 REST API `TestTimeColumn` tests pass (insert/retrieve, nullable, ORM, filter)
- [x] 3 Worker `TestWorkerTimeColumn` tests pass (insert/retrieve, nullable, ORM)
- [x] Full REST API suite: 71/71 passed
- [x] Full Worker suite: 54/54 passed
- [x] 16 unit tests pass
- [x] `pre-commit run --all-files` passes

Closes #18 (Time portion)